### PR TITLE
Remove firebase auth

### DIFF
--- a/src/android/GoogleSignInPlugin.java
+++ b/src/android/GoogleSignInPlugin.java
@@ -110,7 +110,7 @@ public class GoogleSignInPlugin extends CordovaPlugin {
             try {
                 SignInCredential credential = mOneTapSigninClient.getSignInCredentialFromIntent(data);
                 firebaseAuthWithGoogle(credential.getGoogleIdToken());
-            } catch(ApiException ex) {
+            } catch (ApiException ex) {
                 String errorMessage = "";
                 switch (ex.getStatusCode()) {
                     case CommonStatusCodes.CANCELED:
@@ -161,7 +161,7 @@ public class GoogleSignInPlugin extends CordovaPlugin {
         SharedPreferences sharedPreferences = getSharedPreferences();
         boolean shouldShowOneTapUI = sharedPreferences.getBoolean(Constants.PREF_SHOW_ONE_TAP_UI, true);
 
-        if(shouldShowOneTapUI) {
+        if (shouldShowOneTapUI) {
             cordova.setActivityResultCallback(this);
             mOneTapSigninClient = Identity.getSignInClient(mContext);
             mSigninRequest = BeginSignInRequest.builder()
@@ -224,7 +224,7 @@ public class GoogleSignInPlugin extends CordovaPlugin {
             @Override
             public void onComplete(@NonNull Task<AuthResult> task) {
 
-                if(task.isSuccessful()) {
+                if (task.isSuccessful()) {
                     FirebaseUser user = mAuth.getCurrentUser();
                     user.getIdToken(false).addOnSuccessListener(new OnSuccessListener<GetTokenResult>() {
                         @Override
@@ -283,8 +283,8 @@ public class GoogleSignInPlugin extends CordovaPlugin {
         Date now = new Date();
         long coolingStartTime = sharedPreferences.getLong(Constants.PREF_COOLING_START_TIME, now.getTime());
 
-        int daysApart = (int)((now.getTime() - coolingStartTime) / (1000*60*60*24l));
-        if(daysApart >= 1) {
+        int daysApart = (int) ((now.getTime() - coolingStartTime) / (1000 * 60 * 60 * 24l));
+        if (daysApart >= 1) {
             SharedPreferences.Editor preferences = sharedPreferences.edit();
             preferences.putBoolean(Constants.PREF_SHOW_ONE_TAP_UI, true);
             preferences.putLong(Constants.PREF_COOLING_START_TIME, 0L);
@@ -326,6 +326,6 @@ public class GoogleSignInPlugin extends CordovaPlugin {
     }
 
     private SharedPreferences getSharedPreferences() {
-         return mContext.getSharedPreferences(Constants.PREF_FILENAME, Context.MODE_PRIVATE);
+        return mContext.getSharedPreferences(Constants.PREF_FILENAME, Context.MODE_PRIVATE);
     }
 }

--- a/src/android/GoogleSignInPlugin.java
+++ b/src/android/GoogleSignInPlugin.java
@@ -51,7 +51,7 @@ public class GoogleSignInPlugin extends CordovaPlugin {
     private FirebaseAuth mAuth;
 
     private SignInClient mOneTapSigninClient;
-    private BeginSignInRequest mSiginRequest;
+    private BeginSignInRequest mSigninRequest;
 
     private Context mContext;
     private Activity mCurrentActivity;
@@ -164,22 +164,23 @@ public class GoogleSignInPlugin extends CordovaPlugin {
         if(shouldShowOneTapUI) {
             cordova.setActivityResultCallback(this);
             mOneTapSigninClient = Identity.getSignInClient(mContext);
-            mSiginRequest = BeginSignInRequest.builder()
-                    .setPasswordRequestOptions(BeginSignInRequest.PasswordRequestOptions.builder().build())
+            mSigninRequest = BeginSignInRequest.builder()
                     .setGoogleIdTokenRequestOptions(BeginSignInRequest.GoogleIdTokenRequestOptions.builder()
                             .setSupported(true)
-                            .setFilterByAuthorizedAccounts(false)
-                            .setServerClientId(this.cordova.getActivity().getResources().getString(getAppResource("default_client_id", "string")))
+                            .setServerClientId(this.cordova.getActivity().getResources()
+                                    .getString(getAppResource("default_client_id", "string")))
+                            .setFilterByAuthorizedAccounts(true)
                             .build())
-                    .setAutoSelectEnabled(true)
                     .build();
 
-            mOneTapSigninClient.beginSignIn(mSiginRequest)
+            mOneTapSigninClient.beginSignIn(mSigninRequest)
                     .addOnSuccessListener(new OnSuccessListener<BeginSignInResult>() {
                         @Override
                         public void onSuccess(BeginSignInResult beginSignInResult) {
                             try {
-                                mCurrentActivity.startIntentSenderForResult(beginSignInResult.getPendingIntent().getIntentSender(), RC_ONE_TAP, null, 0, 0, 0);
+                                mCurrentActivity.startIntentSenderForResult(
+                                        beginSignInResult.getPendingIntent().getIntentSender(), RC_ONE_TAP, null, 0, 0,
+                                        0);
                             } catch (IntentSender.SendIntentException ex) {
                                 ex.printStackTrace();
                                 mCallbackContext.error(getErrorMessageInJsonString(ex.getMessage()));
@@ -258,7 +259,8 @@ public class GoogleSignInPlugin extends CordovaPlugin {
 
     private GoogleSignInOptions getGoogleSignInOptions() {
         GoogleSignInOptions gso = new GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
-                .requestIdToken(this.cordova.getActivity().getResources().getString(getAppResource("default_client_id", "string")))
+                .requestIdToken(this.cordova.getActivity().getResources()
+                        .getString(getAppResource("default_client_id", "string")))
                 .requestEmail()
                 .build();
         return gso;


### PR DESCRIPTION
This PR modifies the package to remove the additional firebase step to ensure compatibility with the server implementation

Test as normal as described in the readme file. 

Please note that we're preferring `.oneTapLogin` to `signIn` as signIn is [legacy](https://developers.google.com/identity/sign-in/android/start-integrating) although they both work.