### PR TITLE
Activate cooldown only when user exceeds cancellation limit

### DIFF
--- a/src/android/Constants.java
+++ b/src/android/Constants.java
@@ -5,6 +5,7 @@ public class Constants {
 
     public static final String PREF_SHOW_ONE_TAP_UI                 = "pref_show_one_tap_ui";
     public static final String PREF_COOLING_START_TIME              = "pref_cooling_start_time";
+    public static final String PREF_CANCEL_TIME_ARRAY_STRING        = "pref_cancel_time_array_string";
 
     public static final String CORDOVA_ACTION_ONE_TAP_LOGIN         = "oneTapLogin";
     public static final String CORDOVA_ACTION_IS_SIGNEDIN           = "isSignedIn";


### PR DESCRIPTION
Stacked on https://github.com/platogo/cordova-plugin-google-signin/pull/2

Cooldown time is only activated when the user cancels thrice in 15 minutes

How to test

- Try to sign in with google on SMS
- Cancel the sign in attempt
- Try signing in again then cancel
- Repeat one more time
- Now try to login again, you should see the error popup
- Wait 15 minutes and then log in again.
- Log in should be successful now