### PR TITLE
Remove GoogleUtilities pod

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -57,7 +57,6 @@
             </config>
             <pods use-frameworks="true">
               <pod name="GoogleSignIn" spec="~> 6.2.4" />
-              <pod name="GoogleUtilities" spec="~> 7.11.0" />
             </pods>
           </podspec>
 


### PR DESCRIPTION
We're removing this pod because it's clashing with the version in the firebasex plugin